### PR TITLE
Fix: Restore code cell type in organization identifiers section

### DIFF
--- a/component_check_quality.ipynb
+++ b/component_check_quality.ipynb
@@ -1,16 +1,4 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "colab": {
-      "provenance": [],
-      "toc_visible": true
-    },
-    "kernelspec": {
-      "name": "python3",
-      "display_name": "Python 3"
-    }
-  },
   "cells": [
     {
       "cell_type": "markdown",
@@ -74,9 +62,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "FpZvLuscPAf7"
       },
+      "outputs": [],
       "source": [
         "%%sql\n",
         "SELECT\n",
@@ -105,9 +95,7 @@
         "    license,\n",
         "    publicationpolicy,\n",
         "    ocds_version;\n"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -139,9 +127,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "3f-D5_r5ThY_"
       },
+      "outputs": [],
       "source": [
         "%%sql release_tag_section_summary <<\n",
         "WITH contract_implementation AS (\n",
@@ -188,20 +178,18 @@
         "FROM\n",
         "    sections\n",
         "LEFT JOIN contract_implementation USING (collection_id, release_type, tag);\n"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "M-difjEFBSmB"
       },
+      "outputs": [],
       "source": [
         "release_tag_section_summary"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -232,9 +220,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "U-Sw5-X741c7"
       },
+      "outputs": [],
       "source": [
         "%%sql\n",
         "WITH date_frequency AS (\n",
@@ -270,9 +260,7 @@
         "    collection_id ASC,\n",
         "    release_type ASC,\n",
         "    release_count DESC;\n"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -305,9 +293,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "HRweYx7nUvRE"
       },
+      "outputs": [],
       "source": [
         "%%sql\n",
         "SELECT DISTINCT ON (\n",
@@ -323,9 +313,7 @@
         "    collection_id,\n",
         "    release_type,\n",
         "    language;\n"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -390,9 +378,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "lGQMqdTjmmXP"
       },
+      "outputs": [],
       "source": [
         "%%sql\n",
         "WITH release_counts AS (\n",
@@ -423,9 +413,7 @@
         "GROUP BY\n",
         "    collection_id,\n",
         "    release_type;\n"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -438,9 +426,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "zojrnAxlke2p"
       },
+      "outputs": [],
       "source": [
         "%%sql release_count_summary <<\n",
         "WITH release_counts AS (\n",
@@ -471,20 +461,18 @@
         "    collection_id,\n",
         "    release_type,\n",
         "    release_count;\n"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "8273QQnaecKT"
       },
+      "outputs": [],
       "source": [
         "release_count_summary"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -497,9 +485,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "sJ40ZMqF7DnI"
       },
+      "outputs": [],
       "source": [
         "%%sql release_counts <<\n",
         "WITH release_counts AS (\n",
@@ -530,20 +520,18 @@
         "    collection_id,\n",
         "    release_type,\n",
         "    release_count;\n"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "yeBOaDsO6uDS"
       },
+      "outputs": [],
       "source": [
         "plot_release_count(release_counts)"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -563,9 +551,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "RTJ8BwXBSrrw"
       },
+      "outputs": [],
       "source": [
         "%%sql multiple_release_examples <<\n",
         "WITH ranked_ocids AS (\n",
@@ -604,20 +594,18 @@
         "        WHERE\n",
         "            row_number <= 5\n",
         "    );\n"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "G7zsQ7Jvofge"
       },
+      "outputs": [],
       "source": [
         "render_json(multiple_release_examples[\"release_package\"][0])"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -630,15 +618,15 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "YyL6ruuNRTA0"
       },
+      "outputs": [],
       "source": [
         "# spreadsheet_name = ''\n",
         "# save_dataframe_to_spreadsheet(multiple_release_examples, f'{spreadsheet_name}_multiple_releases')"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -673,9 +661,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "7IoW8sC2hkLc"
       },
+      "outputs": [],
       "source": [
         "%%sql\n",
         "SELECT\n",
@@ -691,9 +681,7 @@
         "        ocid = release_id\n",
         "        OR ocid ILIKE '%%' || release_id || '%%'\n",
         "    )\n"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -706,9 +694,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "iqTIUf3s7p85"
       },
+      "outputs": [],
       "source": [
         "%%sql\n",
         "SELECT\n",
@@ -724,9 +714,7 @@
         "    release_id\n",
         "HAVING\n",
         "    count(*) > 1\n"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -739,9 +727,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "BYhoit7Nn53n"
       },
+      "outputs": [],
       "source": [
         "%%sql duplicate_release_ids <<\n",
         "WITH release_ids AS (\n",
@@ -783,31 +773,29 @@
         "        WHERE\n",
         "            row_number <= 5\n",
         "    );\n"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "GmX3uLJ9Ui6s"
       },
+      "outputs": [],
       "source": [
         "render_json(duplicate_release_ids[\"release_package\"][0])"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "q16QKC2WqAz2"
       },
+      "outputs": [],
       "source": [
         "# save_dataframe_to_spreadsheet(duplicate_release_ids, f'{spreadsheet_name}_duplicate_release_ids')"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -843,9 +831,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "_QinRGvas2lN"
       },
+      "outputs": [],
       "source": [
         "%%sql\n",
         "SELECT\n",
@@ -894,9 +884,7 @@
         "    contracts_summary.collection_id ASC,\n",
         "    contracts_summary.release_type ASC,\n",
         "    contract_count DESC\n"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -913,9 +901,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "nT9U0L1weBr4"
       },
+      "outputs": [],
       "source": [
         "%%sql\n",
         "SELECT\n",
@@ -948,9 +938,7 @@
         "    tender_summary.release_type,\n",
         "    award_contract_match,\n",
         "    tender_award_match;\n"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -976,9 +964,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "jMjS-9MS1it_"
       },
+      "outputs": [],
       "source": [
         "%%sql example_releases <<\n",
         "WITH examples AS (\n",
@@ -1002,20 +992,18 @@
         "SELECT jsonb_build_object('releases', jsonb_agg(release)) AS release_package\n",
         "FROM\n",
         "    examples\n"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "i5cZhi-L5ZCu"
       },
+      "outputs": [],
       "source": [
         "render_json(example_releases[\"release_package\"][0])"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -1062,9 +1050,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "XaF65iyq1YMm"
       },
+      "outputs": [],
       "source": [
         "%%sql organization_identifiers <<\n",
         "SELECT\n",
@@ -1080,40 +1070,46 @@
         "    parties_summary\n",
         "WHERE\n",
         "    collection_id IN :collection_ids;\n"
-      ],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "organization_identifiers.groupby([\"collection_id\", \"release_type\", \"scheme\"]).sample(n=3)"
-      ],
-      "metadata": {
-        "collapsed": false
-      }
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "### Item classifications"
-      ],
-      "metadata": {
-        "collapsed": false
-      }
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "Use this section to check whether the data includes item classifications."
-      ],
-      "metadata": {
-        "collapsed": false
-      }
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
+      "metadata": {
+        "collapsed": false,
+        "vscode": {
+          "languageId": "plaintext"
+        }
+      },
+      "outputs": [],
+      "source": [
+        "organization_identifiers.groupby([\"collection_id\", \"release_type\", \"scheme\"]).sample(n=3)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "collapsed": false
+      },
+      "source": [
+        "### Item classifications"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "collapsed": false
+      },
+      "source": [
+        "Use this section to check whether the data includes item classifications."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "collapsed": false
+      },
       "outputs": [],
       "source": [
         "%%sql\n",
@@ -1169,23 +1165,23 @@
         "    scheme,\n",
         "    stage\n",
         "ORDER BY stage;\n"
-      ],
-      "metadata": {
-        "collapsed": false
-      }
+      ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "Select a random sample of 3 identifiers for each item identifier scheme:"
-      ],
       "metadata": {
         "collapsed": false
-      }
+      },
+      "source": [
+        "Select a random sample of 3 identifiers for each item identifier scheme:"
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
+      "metadata": {
+        "collapsed": false
+      },
       "outputs": [],
       "source": [
         "%%sql item_identifiers <<\n",
@@ -1231,21 +1227,18 @@
         "FROM\n",
         "    items\n",
         "WHERE id IS NOT NULL;\n"
-      ],
-      "metadata": {
-        "collapsed": false
-      }
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
+      "metadata": {
+        "collapsed": false
+      },
       "outputs": [],
       "source": [
         "item_identifiers.groupby([\"collection_id\", \"release_type\", \"stage\", \"scheme\"]).sample(n=3)"
-      ],
-      "metadata": {
-        "collapsed": false
-      }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -1281,9 +1274,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "8BnWpi2pmqAV"
       },
+      "outputs": [],
       "source": [
         "%%sql\n",
         "WITH documents AS (\n",
@@ -1367,9 +1362,7 @@
         "ORDER BY\n",
         "    collection_id,\n",
         "    release_type;\n"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -1393,20 +1386,22 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "rdfGKYmN3VbH"
       },
+      "outputs": [],
       "source": [
         "country = \"Paraguay\""
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "iMPnnFMvmnNY"
       },
+      "outputs": [],
       "source": [
         "%%sql\n",
         "SELECT\n",
@@ -1446,9 +1441,7 @@
         "    rank <= 3\n",
         "ORDER BY\n",
         "    scheme;\n"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -1499,9 +1492,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "u4SjRfkeA-32"
       },
+      "outputs": [],
       "source": [
         "%%sql\n",
         "SELECT\n",
@@ -1551,50 +1546,53 @@
         "    collection_id,\n",
         "    release_type,\n",
         "    role;\n"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "### OCID modeling"
-      ],
       "metadata": {
         "id": "8aERQ1ZbsR99"
-      }
+      },
+      "source": [
+        "### OCID modeling"
+      ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "Use this section to check if the OCID is being modeled as expected"
-      ],
       "metadata": {
         "id": "DiQ4pEkLvDnX"
-      }
+      },
+      "source": [
+        "Use this section to check if the OCID is being modeled as expected"
+      ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "#### Number of tenders per ocid\n"
-      ],
       "metadata": {
         "id": "SHmE4lEdu713"
-      }
+      },
+      "source": [
+        "#### Number of tenders per ocid\n"
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "F4-Dj3GusTzI"
+      },
       "source": [
         "Use this section to check there is always only one tender per ocid.\n",
         "\n",
         "If the data contains planning data and multiple tenders per ocid, it might indicate that the ocid is being assigned in the planning stage, and the planning can have more than one tender, for example, due to unsuccessful tenders."
-      ],
-      "metadata": {
-        "id": "F4-Dj3GusTzI"
-      }
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "fyUd67h9tr8g"
+      },
+      "outputs": [],
       "source": [
         "%%sql\n",
         "SELECT\n",
@@ -1605,12 +1603,19 @@
         "WHERE collection_id IN :collection_ids\n",
         "GROUP BY ocid\n",
         "ORDER BY cnt DESC;\n"
-      ],
-      "metadata": {
-        "id": "fyUd67h9tr8g"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     }
-  ]
+  ],
+  "metadata": {
+    "colab": {
+      "provenance": [],
+      "toc_visible": true
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
 }

--- a/template_data_quality_feedback.ipynb
+++ b/template_data_quality_feedback.ipynb
@@ -3036,10 +3036,15 @@
       ]
     },
     {
-      "cell_type": "markdown",
+      "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "collapsed": false
+        "collapsed": false,
+        "vscode": {
+          "languageId": "plaintext"
+        }
       },
+      "outputs": [],
       "source": [
         "organization_identifiers.groupby([\"collection_id\", \"release_type\", \"scheme\"]).sample(n=3)"
       ]


### PR DESCRIPTION
Fixed a cell type change in the "organization identifiers" section where a code cell was set to markdown in a previous commit. Restored the cell to a code type to make it executable.