### PR TITLE
Parties: multiple names and ids checks

### DIFF
--- a/component_check_quality.ipynb
+++ b/component_check_quality.ipynb
@@ -1498,13 +1498,17 @@
       "cell_type": "code",
       "source": [
         "%%sql\n",
-        "SELECT identifier, string_agg(name, '; ') AS names, count(distinct name) as total_names, roles\n",
+        "SELECT\n",
+        "    identifier,\n",
+        "    string_agg(name, '; ') AS names,\n",
+        "    count(DISTINCT name) AS total_names,\n",
+        "    roles\n",
         "FROM parties_summary\n",
         "WHERE\n",
-        "        release_type = 'release' AND\n",
-        "        identifier IS NOT NULL and name IS NOT NULL\n",
+        "    release_type = 'release'\n",
+        "    AND identifier IS NOT NULL AND name IS NOT NULL\n",
         "GROUP BY identifier, roles\n",
-        "HAVING COUNT(DISTINCT name) > 1\n",
+        "HAVING count(DISTINCT name) > 1\n",
         "ORDER BY total_names DESC;\n"
       ],
       "metadata": {
@@ -1571,13 +1575,16 @@
       "cell_type": "code",
       "source": [
         "%%sql\n",
-        "SELECT name, string_agg(identifier, ', ') AS identifiers, roles\n",
+        "SELECT\n",
+        "    name,\n",
+        "    string_agg(identifier, ', ') AS identifiers,\n",
+        "    roles\n",
         "FROM parties_summary\n",
         "WHERE\n",
-        "        release_type = 'release' AND\n",
-        "        identifier IS NOT NULL\n",
+        "    release_type = 'release'\n",
+        "    AND identifier IS NOT NULL\n",
         "GROUP BY name, roles\n",
-        "HAVING COUNT(DISTINCT identifier) > 1"
+        "HAVING count(DISTINCT identifier) > 1\n"
       ],
       "metadata": {
         "id": "BHb-K53Hm4kr"

--- a/template_data_quality_feedback.ipynb
+++ b/template_data_quality_feedback.ipynb
@@ -2027,16 +2027,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
-        "id": "view-in-github"
-      },
-      "source": [
-        "<a href=\"https://colab.research.google.com/github/open-contracting/notebooks-ocds/blob/parties-mltiple-names-ids/component_check_quality.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
         "id": "0jMaeqCJPA5J"
       },
       "source": [
@@ -3465,6 +3455,170 @@
     {
       "cell_type": "markdown",
       "metadata": {
+        "id": "LJ3eDzNYOxgb"
+      },
+      "source": [
+        "### Consistent party name-ID pairs across contracting processes\n",
+        "\n",
+        "**Note**: This check will be [included in Pelican](https://github.com/open-contracting/pelican-backend/issues/28) and should be removed from here when implemented.\n",
+        "\n",
+        "This section evaluates whether the parties section incorporates organizations with the same name but different identifiers, and whether there are organizations with the same ID but different names."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "n-xFQx8mlOu9"
+      },
+      "source": [
+        "#### Same ID with different names\n",
+        "\n",
+        "Use this section to check that the party name remains consistent with its id across contracting processes.\n",
+        "\n",
+        "Check the number of unique `parties/name` per `parties/identifier` (`parties/identifier/scheme` and `parties/identifier/id` pair) and `parties/role`.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "R5tMfAcMmsY_"
+      },
+      "outputs": [],
+      "source": [
+        "%%sql\n",
+        "WITH id_per_name AS (\n",
+        "    SELECT\n",
+        "        identifier,\n",
+        "        roles,\n",
+        "        count(DISTINCT name) AS different_names\n",
+        "    FROM parties_summary\n",
+        "    WHERE\n",
+        "        release_type = 'release'\n",
+        "        AND\n",
+        "        identifier IS NOT NULL AND name IS NOT NULL\n",
+        "    GROUP BY identifier, roles\n",
+        ")\n",
+        "\n",
+        "SELECT\n",
+        "    roles,\n",
+        "    count(*) AS total_names,\n",
+        "    count(*) FILTER (WHERE different_names > 1) AS ids_with_multiple_names\n",
+        "FROM id_per_name\n",
+        "GROUP BY roles\n",
+        "ORDER BY ids_with_multiple_names DESC;\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "XDrzXACHnV2V"
+      },
+      "source": [
+        "Full list of parties with the same `parties/identifier` but different `parties/name`"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "g1FJKL4YnWdJ"
+      },
+      "outputs": [],
+      "source": [
+        "%%sql\n",
+        "SELECT\n",
+        "    identifier,\n",
+        "    string_agg(name, '; ') AS names,\n",
+        "    count(DISTINCT name) AS total_names,\n",
+        "    roles\n",
+        "FROM parties_summary\n",
+        "WHERE\n",
+        "    release_type = 'release'\n",
+        "    AND identifier IS NOT NULL AND name IS NOT NULL\n",
+        "GROUP BY identifier, roles\n",
+        "HAVING count(DISTINCT name) > 1\n",
+        "ORDER BY total_names DESC;\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "RzwmG14znMdj"
+      },
+      "source": [
+        "#### Same name with different IDs\n",
+        "\n",
+        "Use this section to check that the party id remains consistent with its name across contracting processes.\n",
+        "\n",
+        "Check the number of unique `parties/identifer` (`parties/identifier/scheme` and `parties/identifier/id` pair) per `parties/name` and `parties/role`."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "2Pq1sUbonNMh"
+      },
+      "outputs": [],
+      "source": [
+        "%%sql\n",
+        "WITH id_per_name AS (\n",
+        "    SELECT\n",
+        "        name,\n",
+        "        roles,\n",
+        "        count(DISTINCT identifier) AS different_ids\n",
+        "    FROM parties_summary\n",
+        "    WHERE\n",
+        "        release_type = 'release'\n",
+        "        AND\n",
+        "        identifier IS NOT NULL\n",
+        "    GROUP BY name, roles\n",
+        ")\n",
+        "\n",
+        "SELECT\n",
+        "    roles,\n",
+        "    count(*) AS total_names,\n",
+        "    count(*) FILTER (WHERE different_ids > 1) AS names_with_multiple_ids\n",
+        "FROM id_per_name\n",
+        "GROUP BY roles\n",
+        "ORDER BY names_with_multiple_ids DESC;\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "VEhfUU-mmwJH"
+      },
+      "source": [
+        "\n",
+        "Full list of parties with the same `parties/name` but different `parties/identifier`"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "BHb-K53Hm4kr"
+      },
+      "outputs": [],
+      "source": [
+        "%%sql\n",
+        "SELECT\n",
+        "    name,\n",
+        "    string_agg(identifier, ', ') AS identifiers,\n",
+        "    roles\n",
+        "FROM parties_summary\n",
+        "WHERE\n",
+        "    release_type = 'release'\n",
+        "    AND identifier IS NOT NULL\n",
+        "GROUP BY name, roles\n",
+        "HAVING count(DISTINCT identifier) > 1\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
         "id": "WJSIS4xfA-ER"
       },
       "source": [
@@ -3497,9 +3651,7 @@
         "id": "pCwl5SeoIZJo"
       },
       "source": [
-        "Use this section to check whether the data includes organization identifiers for buyers, procuring entities, suppliers and tenderers.\n",
-        "\n",
-        "In addition, this section evaluates whether the parties section incorporates organizations with the same names but different identifiers, and whether there are organizations with the same ID but different names."
+        "Use this section to check whether the data includes organization identifiers for buyers, procuring entities, suppliers and tenderers."
       ]
     },
     {
@@ -3624,208 +3776,6 @@
         "WHERE collection_id IN :collection_ids\n",
         "GROUP BY ocid\n",
         "ORDER BY cnt DESC;\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "n-xFQx8mlOu9"
-      },
-      "source": [
-        "### Parties identifiers and names\n",
-        "\n",
-        "Use this section to analyze the inclusion of organizations in the *parties* section.  \n",
-        "Specifically, this section examines the existence of organizations with identical `identifier` (Hyphenation of identifier/scheme and identifier/id in the party object) values but different `parties/name` values, as well as organizations with identical `parties/name` values but different `identifier` values.\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "ODYAratwmozn"
-      },
-      "source": [
-        "Same ID but multiple names\n",
-        "\n",
-        "The following check evaluates the number of unique `identifier` (Hyphenation of identifier/scheme and identifier/id in the party object) per `party/role` and the number of `identifier` with multiple `party/name`"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "R5tMfAcMmsY_"
-      },
-      "outputs": [],
-      "source": [
-        "%%sql\n",
-        "WITH distinct_party_rows AS (\n",
-        "    SELECT DISTINCT\n",
-        "        p.identifier,\n",
-        "        p.roles::text AS role,\n",
-        "        p.name\n",
-        "    FROM parties_summary AS p\n",
-        "    WHERE\n",
-        "        p.release_type = 'release'\n",
-        "        AND p.identifier IS NOT NULL\n",
-        "        AND p.name IS NOT NULL\n",
-        "),\n",
-        "\n",
-        "names_per_id AS (\n",
-        "    SELECT\n",
-        "        identifier,\n",
-        "        role,\n",
-        "        count(DISTINCT name) AS different_names\n",
-        "    FROM distinct_party_rows\n",
-        "    GROUP BY identifier, role\n",
-        ")\n",
-        "\n",
-        "SELECT\n",
-        "    role,\n",
-        "    count(*) AS total_ids,\n",
-        "    count(*) FILTER (WHERE different_names > 1) AS ids_with_multiple_names,\n",
-        "    round(\n",
-        "        (count(*) FILTER (WHERE different_names > 1))::numeric\n",
-        "        / nullif(count(*)::numeric, 0) * 100,\n",
-        "        2\n",
-        "    ) AS prop_with_multiple_names\n",
-        "FROM names_per_id\n",
-        "GROUP BY role\n",
-        "ORDER BY total_ids DESC;\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "XDrzXACHnV2V"
-      },
-      "source": [
-        "Same ID but multiple names\n",
-        "\n",
-        "Full list of parties with the same `identifier` but multiple `party/name`"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "g1FJKL4YnWdJ"
-      },
-      "outputs": [],
-      "source": [
-        "%%sql\n",
-        "SELECT\n",
-        "    p.identifier,\n",
-        "    (p.roles::text) AS role,\n",
-        "    count(DISTINCT p.name) AS different_names\n",
-        "FROM parties_summary AS p\n",
-        "WHERE\n",
-        "    p.release_type = 'release'\n",
-        "    AND p.identifier IS NOT NULL\n",
-        "    AND p.name IS NOT NULL\n",
-        "GROUP BY\n",
-        "    p.identifier, role\n",
-        "HAVING\n",
-        "    count(DISTINCT p.name) > 1\n",
-        "ORDER BY\n",
-        "    different_names DESC, p.identifier ASC;\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "RzwmG14znMdj"
-      },
-      "source": [
-        "Same Name but Multiple IDs\n",
-        "\n",
-        "The following check evaluates the number of unique IDs per `parties/roles` and the number of `parties/name` with multiple `identifier` (Hyphenation of identifier/scheme and identifier/id in the party object)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "2Pq1sUbonNMh"
-      },
-      "outputs": [],
-      "source": [
-        "%%sql\n",
-        "WITH id_per_name AS (\n",
-        "    SELECT\n",
-        "        name,\n",
-        "        roles::text AS role,\n",
-        "        count(DISTINCT identifier) AS different_ids\n",
-        "    FROM parties_summary\n",
-        "    WHERE\n",
-        "        --Use releases, not compiled releases\n",
-        "        collection_id IN :collection_ids\n",
-        "        AND\n",
-        "        identifier IS NOT NULL\n",
-        "    GROUP BY name, role\n",
-        ")\n",
-        "\n",
-        "SELECT\n",
-        "    role,\n",
-        "    count(*) AS total_ids,\n",
-        "    count(*) FILTER (WHERE different_ids > 1) AS names_with_multiple_ids,\n",
-        "    round(\n",
-        "        (count(*) FILTER (WHERE different_ids > 1))::numeric\n",
-        "        / count(*)::numeric * 100,\n",
-        "        2\n",
-        "    ) AS prop_with_multiple_ids\n",
-        "FROM id_per_name\n",
-        "GROUP BY role\n",
-        "ORDER BY prop_with_multiple_ids DESC;\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "VEhfUU-mmwJH"
-      },
-      "source": [
-        "Same Name but Multiple IDs\n",
-        "\n",
-        "Full list of parties with the same `parties/name` but multiple `identifier`"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "BHb-K53Hm4kr"
-      },
-      "outputs": [],
-      "source": [
-        "# Check examples of parties with the same name but multiple identifiers\n",
-        "%%sql\n",
-        "WITH names AS (\n",
-        "  SELECT DISTINCT\n",
-        "    p.name,\n",
-        "    p.identifier,\n",
-        "    p.roles::text AS role,\n",
-        "    p.party -> 'identifier' ->> 'scheme' AS scheme_identifier\n",
-        "  FROM parties_summary p\n",
-        "  WHERE\n",
-        "    p.collection_id = 764\n",
-        "    AND p.identifier IS NOT NULL\n",
-        "),\n",
-        "same_name_multiple_ids AS (\n",
-        "  SELECT\n",
-        "    name\n",
-        "  FROM names\n",
-        "  GROUP BY name\n",
-        "  HAVING COUNT(DISTINCT identifier) > 1\n",
-        ")\n",
-        "SELECT\n",
-        "  n.name,\n",
-        "  n.identifier,\n",
-        "  n.role,\n",
-        "  n.scheme_identifier\n",
-        "FROM names n\n",
-        "JOIN same_name_multiple_ids m USING (name)\n",
-        "ORDER BY\n",
-        "  n.name, n.identifier;"
       ]
     }
   ],


### PR DESCRIPTION
Added some queries we ran for a project to evaluate the inclusion of parties 
with the same ID but different names, and those with the same name but different IDs. 
I haven't opened a new issue in Pelican backend, since there’s already one to 
incorporate these tests into the tool: https://github.com/open-contracting/pelican-backend/issues/28
